### PR TITLE
Limit Visualizer Speed to 120 fps

### DIFF
--- a/Prefs/Resources/App.plist
+++ b/Prefs/Resources/App.plist
@@ -356,7 +356,7 @@
 			<key>min</key>
 			<real>5</real>
 			<key>max</key>
-			<real>240</real>
+			<real>120</real>
 			<key>showValue</key>
 			<true/>
 			<key>isSegmented</key>


### PR DESCRIPTION
No Apple devices can go over 120 fps so there is no need for a higher than that speed.